### PR TITLE
Prevent enable pay button when it shouldn't

### DIFF
--- a/library/src/main/java/company/tap/gosellapi/internal/activities/GoSellPaymentActivity.java
+++ b/library/src/main/java/company/tap/gosellapi/internal/activities/GoSellPaymentActivity.java
@@ -423,7 +423,6 @@ public class GoSellPaymentActivity extends BaseActivity implements PaymentOption
     private void startWebPaymentProcess1() {
         if (selectedCurrencyAsynchronous) {
             PaymentDataManager.getInstance().initiatePayment(webPaymentViewModel, this);
-            payButton.setEnabled(true);
             payButton.getLoadingView().start();
 
         } else {


### PR DESCRIPTION
If the user selects an asynchronous payment method, the button gets enabled and if pressed it throws a NPE. This PR corrects this behavior